### PR TITLE
OPS-2738 Add Dockerfile for OpenJDK Java 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,3 +82,27 @@ jobs:
           else
             echo "Skipping push to dockerhub on PR";
           fi
+
+    # [Stage 2] [Job 3]
+    - stage: build and deploy
+      env: java=stretch-slim-openjdk-java8
+      install:
+        - max=100; i=0; while [ $i -lt $max ]; do if sudo apt-get update; then break; else i=$((i+1)); fi done
+        - max=100; i=0; while [ $i -lt $max ]; do if sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce; then break; else i=$((i+1)); fi done
+      before_script:
+        - ./tests/build.sh "${image}" "${java}"
+        - ./tests/check.sh "${image}" "${java}" "8"
+      script:
+        - if [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then
+            echo "${DOCKERHUB_PASSWORD}" | docker login --username "${DOCKERHUB_USERNAME}" --password-stdin &&
+            if [ "${TRAVIS_BRANCH}" == "master" ]; then
+              docker push "${image}:${java}";
+            elif [ -n "${TRAVIS_TAG}" ]; then
+              docker tag "${image}:${java}" "${image}:${java}-${TRAVIS_TAG}";
+              docker push "${image}:${java}-${TRAVIS_TAG}";
+            else
+              echo "Skipping push to dockerhub on normal branches";
+            fi
+          else
+            echo "Skipping push to dockerhub on PR";
+          fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,9 @@ jobs:
     ###
     - stage: static file analysis
       install:
+        # Repeat "apt-get update" multiple times in case of network issues
         - max=100; i=0; while [ $i -lt $max ]; do if sudo apt-get update; then break; else i=$((i+1)); fi done
+        # Repeat "apt-get install" multiple times in case of network issues
         - max=100; i=0; while [ $i -lt $max ]; do if sudo apt-get -y install moreutils; then break; else i=$((i+1)); fi done
         - git clone https://github.com/Flaconi/awesome-ci /tmp/awesome-ci
         - sh -c "cd /tmp/awesome-ci && ./configure --prefix=/usr/local && sudo make install"

--- a/stretch-oracle-java8/Dockerfile
+++ b/stretch-oracle-java8/Dockerfile
@@ -36,7 +36,7 @@ RUN set -x \
 	&& apt-get install --no-install-recommends --no-install-suggests -y \
 		${BUILD_DEPS} \
 	# Install Oracle deb repositories
-	&& apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "${ORACLE_KEY}" \
+	&& apt-key adv --no-tty --keyserver keyserver.ubuntu.com --recv-keys "${ORACLE_KEY}" \
 	&& add-apt-repository "${ORACLE_REP}" \
 	&& apt-get update \
 	# Install Oracle Java (auto-accepting licence with YES prepended) and other tools

--- a/stretch-oracle-java9/Dockerfile
+++ b/stretch-oracle-java9/Dockerfile
@@ -36,7 +36,7 @@ RUN set -x \
 	&& apt-get install --no-install-recommends --no-install-suggests -y \
 		${BUILD_DEPS} \
 	# Install Oracle deb repositories
-	&& apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "${ORACLE_KEY}" \
+	&& apt-key adv --no-tty --keyserver keyserver.ubuntu.com --recv-keys "${ORACLE_KEY}" \
 	&& add-apt-repository "${ORACLE_REP}" \
 	&& apt-get update \
 	# Install Oracle Java (auto-accepting licence with YES prepended) and other tools

--- a/stretch-slim-openjdk-java8/Dockerfile
+++ b/stretch-slim-openjdk-java8/Dockerfile
@@ -1,0 +1,37 @@
+FROM debian:stretch-slim
+LABEL maintainer="Patrick Plocke <patrick.plocke@flaconi.de>"
+
+# This file was heavily inspired by: https://github.com/docker-library/openjdk/blob/894a19d0401349d39ced7764190ea6263bb17ba0/11/jre/slim/Dockerfile
+
+
+###
+### Build arguments
+###
+ARG JAVA_VERSION=8
+
+###
+### Installation
+###
+
+# Default to UTF-8 file.encoding
+ENV LANG C.UTF-8
+
+# Do some fancy footwork to create a JAVA_HOME that's cross-architecture-safe
+RUN ln -svT "/usr/lib/jvm/java-8-openjdk-$(dpkg --print-architecture)" /docker-java-home
+ENV JAVA_HOME /docker-java-home
+
+# Bootstrap system
+RUN set -ex \
+	&& mkdir -p /usr/share/man/man1 \
+	&& apt-get update \
+	&& apt-get upgrade -y \
+	&& apt-get install -y --no-install-recommends \
+		"openjdk-${JAVA_VERSION}-jre-headless" \
+	&& rm -rf /var/lib/apt/lists/*
+
+
+###
+### Default entrypoint
+###
+CMD ["-version"]
+ENTRYPOINT ["java"]

--- a/stretch-slim-oracle-java8/Dockerfile
+++ b/stretch-slim-oracle-java8/Dockerfile
@@ -38,7 +38,7 @@ RUN set -x \
 	# Fix Debian slim env
 	&& mkdir -p /usr/share/man/man1 \
 	# Install Oracle deb repositories
-	&& apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "${ORACLE_KEY}" \
+	&& apt-key adv --no-tty --keyserver keyserver.ubuntu.com --recv-keys "${ORACLE_KEY}" \
 	&& add-apt-repository "${ORACLE_REP}" \
 	&& apt-get update \
 	# Install Oracle Java (auto-accepting licence with YES prepended) and other tools

--- a/stretch-slim-oracle-java9/Dockerfile
+++ b/stretch-slim-oracle-java9/Dockerfile
@@ -36,7 +36,7 @@ RUN set -x \
 	&& apt-get install --no-install-recommends --no-install-suggests -y \
 		${BUILD_DEPS} \
 	# Install Oracle deb repositories
-	&& apt-key adv --keyserver keyserver.ubuntu.com --recv-keys "${ORACLE_KEY}" \
+	&& apt-key adv --no-tty --keyserver keyserver.ubuntu.com --recv-keys "${ORACLE_KEY}" \
 	&& add-apt-repository "${ORACLE_REP}" \
 	&& apt-get update \
 	# Install Oracle Java (auto-accepting licence with YES prepended) and other tools

--- a/tests/check.sh
+++ b/tests/check.sh
@@ -14,31 +14,36 @@ if [ ${#} -ne 3 ]; then
 	exit 1
 fi
 
-if [ ! -d "${CWD}/${2}" ]; then
+# Translate arguments into variables
+image_name=${1}
+image_tag=${2}
+java_version=${3}
+
+if [ ! -d "${CWD}/${image_tag}" ]; then
 	echo "Image tag does not exist: '${2}'"
 	exit 1
 fi
 
-if ! [[ ${2} =~ ^[-_.A-Za-z0-9]+$ ]]; then
-	echo "Image tag has invalid characters: '${2}'"
+if ! [[ ${image_tag} =~ ^[-_.A-Za-z0-9]+$ ]]; then
+	echo "Image tag has invalid characters: '${image_tag}'"
 	exit 1
 fi
 
 echo "[CHECK] Checking run"
 echo "------------------------------------------------------------"
-docker run "${1}:${2}"
+docker run "${image_name}:${image_tag}"
 echo
 
 echo "[CHECK] Checking java version"
 echo "------------------------------------------------------------"
-if [[ "${2}" =~ "openjdk" ]]; then
+if [[ "${image_tag}" =~ "openjdk" ]]; then
 	# OpenJDK Java returns a different version string
-	docker run "${1}:${2}" 2>&1 | grep -io "openjdk version \"1.${3}."
+	docker run "${image_name}:${image_tag}" 2>&1 | grep -io "openjdk version \"1.${java_version}."
 else
-	if [ "${3}" -eq "8" ]; then
-		docker run "${1}:${2}" 2>&1 | grep -io "java version \"1.${3}."
+	if [ "${java_version}" -eq "8" ]; then
+		docker run "${image_name}:${image_tag}" 2>&1 | grep -io "java version \"1.${java_version}."
 	else
-		docker run "${1}:${2}" 2>&1 | grep -io "java version \"${3}."
+		docker run "${image_name}:${image_tag}" 2>&1 | grep -io "java version \"${java_version}."
 	fi
 fi
 echo

--- a/tests/check.sh
+++ b/tests/check.sh
@@ -31,9 +31,14 @@ echo
 
 echo "[CHECK] Checking java version"
 echo "------------------------------------------------------------"
-if [ "${3}" -eq "8" ]; then
-	docker run "${1}:${2}" 2>&1 | grep -io "java version \"1.${3}."
+if [[ "${2}" =~ "openjdk" ]]; then
+	# OpenJDK Java returns a different version string
+	docker run "${1}:${2}" 2>&1 | grep -io "openjdk version \"1.${3}."
 else
-	docker run "${1}:${2}" 2>&1 | grep -io "java version \"${3}."
+	if [ "${3}" -eq "8" ]; then
+		docker run "${1}:${2}" 2>&1 | grep -io "java version \"1.${3}."
+	else
+		docker run "${1}:${2}" 2>&1 | grep -io "java version \"${3}."
+	fi
 fi
 echo


### PR DESCRIPTION
Build and publish Docker image with OpenJDK Java 8 inside.

---

I didn't find anything higher than Java 8 for `debian:stretch-slim`:

```bash
$ apt-get update
...
$ apt-cache search openjdk
icedtea-8-plugin - web browser plugin based on OpenJDK and IcedTea to execute Java applets
jtreg - Regression Test Harness for the OpenJDK platform
openjdk-8-dbg - Java runtime based on OpenJDK (debugging symbols)
openjdk-8-demo - Java runtime based on OpenJDK (demos and examples)
openjdk-8-doc - OpenJDK Development Kit (JDK) documentation
openjdk-8-jdk - OpenJDK Development Kit (JDK)
openjdk-8-jdk-headless - OpenJDK Development Kit (JDK) (headless)
openjdk-8-jre - OpenJDK Java runtime, using Hotspot JIT
openjdk-8-jre-headless - OpenJDK Java runtime, using Hotspot JIT (headless)
openjdk-8-jre-zero - Alternative JVM for OpenJDK, using Zero/Shark
openjdk-8-source - OpenJDK Development Kit (JDK) source files
openjdk-8-jre-dcevm - Alternative VM for OpenJDK 8 with enhanced class redefinition
uwsgi-plugin-jvm-openjdk-8 - Java plugin for uWSGI (OpenJDK 8)
uwsgi-plugin-jwsgi-openjdk-8 - JWSGI plugin for uWSGI (OpenJDK 8)
uwsgi-plugin-ring-openjdk-8 - Closure/Ring plugin for uWSGI (OpenJDK 8)
uwsgi-plugin-servlet-openjdk-8 - JWSGI plugin for uWSGI (OpenJDK 8)
```

I'm happy to improve it if there are any suggestions.

## Resources:

- [Official `openjdk` Docker image based on `debian:sid-slim`](https://github.com/docker-library/openjdk/blob/894a19d0401349d39ced7764190ea6263bb17ba0/11/jre/slim/Dockerfile)
- [DigitalOcean: How To Install Java with `apt` on Ubuntu 18.04](https://www.digitalocean.com/community/tutorials/how-to-install-java-with-apt-on-ubuntu-18-04#installing-the-oracle-jdk)