### PR TITLE
OPS-3145 Disable deprecated Java versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,6 @@ services:
   - docker
 
 
-###
-### Env variables
-###
-env:
-  global:
-    - image=flaconi/java-base
-
 jobs:
   include:
     ###
@@ -37,69 +30,21 @@ jobs:
 
     # [Stage 2] [Job 1]
     - stage: build and deploy
-      env: java=stretch-oracle-java8
-      install:
-        - max=100; i=0; while [ $i -lt $max ]; do if sudo apt-get update; then break; else i=$((i+1)); fi done
-        - max=100; i=0; while [ $i -lt $max ]; do if sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce; then break; else i=$((i+1)); fi done
-      before_script:
-        - ./tests/build.sh "${image}" "${java}"
-        - ./tests/check.sh "${image}" "${java}" "8"
-      script:
-        - if [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then
-            echo "${DOCKERHUB_PASSWORD}" | docker login --username "${DOCKERHUB_USERNAME}" --password-stdin &&
-            if [ "${TRAVIS_BRANCH}" == "master" ]; then
-              docker push "${image}:${java}";
-            elif [ -n "${TRAVIS_TAG}" ]; then
-              docker tag "${image}:${java}" "${image}:${java}-${TRAVIS_TAG}";
-              docker push "${image}:${java}-${TRAVIS_TAG}";
-            else
-              echo "Skipping push to dockerhub on normal branches";
-            fi
-          else
-            echo "Skipping push to dockerhub on PR";
-          fi
-
-    # [Stage 2] [Job 2]
-    - stage: build and deploy
-      env: java=stretch-slim-oracle-java8
-      install:
-        - max=100; i=0; while [ $i -lt $max ]; do if sudo apt-get update; then break; else i=$((i+1)); fi done
-        - max=100; i=0; while [ $i -lt $max ]; do if sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce; then break; else i=$((i+1)); fi done
-      before_script:
-        - ./tests/build.sh "${image}" "${java}"
-        - ./tests/check.sh "${image}" "${java}" "8"
-      script:
-        - if [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then
-            echo "${DOCKERHUB_PASSWORD}" | docker login --username "${DOCKERHUB_USERNAME}" --password-stdin &&
-            if [ "${TRAVIS_BRANCH}" == "master" ]; then
-              docker push "${image}:${java}";
-            elif [ -n "${TRAVIS_TAG}" ]; then
-              docker tag "${image}:${java}" "${image}:${java}-${TRAVIS_TAG}";
-              docker push "${image}:${java}-${TRAVIS_TAG}";
-            else
-              echo "Skipping push to dockerhub on normal branches";
-            fi
-          else
-            echo "Skipping push to dockerhub on PR";
-          fi
-
-    # [Stage 2] [Job 3]
-    - stage: build and deploy
       env: java=stretch-slim-openjdk-java8
       install:
         - max=100; i=0; while [ $i -lt $max ]; do if sudo apt-get update; then break; else i=$((i+1)); fi done
         - max=100; i=0; while [ $i -lt $max ]; do if sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce; then break; else i=$((i+1)); fi done
       before_script:
-        - ./tests/build.sh "${image}" "${java}"
-        - ./tests/check.sh "${image}" "${java}" "8"
+        - make build TAG="${java}"
+        - make test  TAG="${java}" VERSION=8
       script:
         - if [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then
-            echo "${DOCKERHUB_PASSWORD}" | docker login --username "${DOCKERHUB_USERNAME}" --password-stdin &&
+            make login USER="${DOCKERHUB_PASSWORD}" PASS="${DOCKERHUB_USERNAME}";
             if [ "${TRAVIS_BRANCH}" == "master" ]; then
-              docker push "${image}:${java}";
+              make push TAG="${java}";
             elif [ -n "${TRAVIS_TAG}" ]; then
-              docker tag "${image}:${java}" "${image}:${java}-${TRAVIS_TAG}";
-              docker push "${image}:${java}-${TRAVIS_TAG}";
+              make tag  TAG="${java}" NEW_TAG="${java}-${TRAVIS_TAG}";
+              make push TAG="${java}-${TRAVIS_TAG}";
             else
               echo "Skipping push to dockerhub on normal branches";
             fi

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,53 @@
+ifneq (,)
+.error This Makefile requires GNU Make.
+endif
+
+.PHONY: help build rebuild tag test pull push login
+
+CURRENT_DIR = $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+FILE = Dockerfile
+IMAGE = flaconi/java-base
+TAG = latest
+
+help:
+	@echo "build       Build the image (TAG is required)"
+	@echo "rebuild     Rebuild the image without cache (TAG is required)"
+	@echo "test        Test the image (TAG is required)"
+	@echo
+	@echo "Available images to build:"
+	@echo "   make build TAG=stretch-oracle-java8"
+	@echo "   make build TAG=stretch-oracle-java9"
+	@echo "   make build TAG=stretch-slim-oracle-java8"
+	@echo "   make build TAG=stretch-slim-oracle-java9"
+	@echo "   make build TAG=stretch-slim-openjdk-java8"
+	@echo
+	@echo "Available images to test:"
+	@echo "   make test TAG=stretch-oracle-java8"
+	@echo "   make test TAG=stretch-oracle-java9"
+	@echo "   make test TAG=stretch-slim-oracle-java8"
+	@echo "   make test TAG=stretch-slim-oracle-java9"
+	@echo "   make test TAG=stretch-slim-openjdk-java8"
+
+build:
+	docker build -t $(IMAGE):$(TAG) -f $(TAG)/$(FILE) $(TAG)
+
+rebuild: pull
+	docker build --no-cache -t $(IMAGE):$(TAG) -f $(TAG)/$(FILE) $(TAG)
+
+test:
+	./tests/check.sh "$(IMAGE)" "$(TAG)" "$(VERSION)"
+
+pull:
+	@grep -E '^\s*FROM' Dockerfile \
+		| sed -e 's/^FROM//g' -e 's/[[:space:]]*as[[:space:]]*.*$$//g' \
+		| xargs -n1 docker pull;
+
+login:
+	yes | docker login --username $(USER) --password $(PASS)
+
+tag:
+	docker tag $(IMAGE):$(TAG) $(IMAGE):$(NEW_TAG)
+
+push:
+	docker push $(IMAGE):$(TAG)

--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ By running any of those Docker images they will simply output their version.
 
 ## Docker images
 
-| Docker Image        | Docker Tag                    | OS                  | Java version  |
-|---------------------|-------------------------------|---------------------|---------------|
-| `flaconi/java-base` | `:stretch-oracle-java8`       | Debian stretch      | Oracle Java 8 |
-| `flaconi/java-base` | `:stretch-oracle-java9`       | Debian stretch      | Oracle Java 9 |
-| `flaconi/java-base` | `:stretch-slim-oracle-java8`  | Debian stretch slim | Oracle Java 8 |
-| `flaconi/java-base` | `:stretch-slim-oracle-java9`  | Debian stretch slim | Oracle Java 9 |
-| `flaconi/java-base` | `:stretch-slim-openjdk-java8` | Debian stretch slim | Open Java 8   |
+| Docker Image        | Docker Tag                    | OS                  | Java version   | Info       |
+|---------------------|-------------------------------|---------------------|----------------|------------|
+| `flaconi/java-base` | `:stretch-oracle-java8`       | Debian stretch      | Oracle Java 8  | deprecated |
+| `flaconi/java-base` | `:stretch-oracle-java9`       | Debian stretch      | Oracle Java 9  | deprecated |
+| `flaconi/java-base` | `:stretch-slim-oracle-java8`  | Debian stretch slim | Oracle Java 8  | deprecated |
+| `flaconi/java-base` | `:stretch-slim-oracle-java9`  | Debian stretch slim | Oracle Java 9  | deprecated |
+| `flaconi/java-base` | `:stretch-slim-openjdk-java8` | Debian stretch slim | Open Java 8    |            |
 
 
 ## License


### PR DESCRIPTION
# Disable deprecated Java versions

* Disable deprecated Java versions
* Provide Makefile for easier builds
* Mention deprecated Java versions in README.md
* Clean up travis.yml